### PR TITLE
Unity 2017.3.0

### DIFF
--- a/Casks/unity-ios-support-for-editor@2017.3.0.rb
+++ b/Casks/unity-ios-support-for-editor@2017.3.0.rb
@@ -6,7 +6,7 @@ cask 'unity-ios-support-for-editor@2017.3.0' do
   name 'Unity iOS Build Support'
   homepage 'https://unity3d.com/unity/'
 
-  depends_on cask: 'unity'
+  depends_on cask: 'unity@2017.3.0'
 
   pkg "UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
 

--- a/Casks/unity-ios-support-for-editor@2017.3.0.rb
+++ b/Casks/unity-ios-support-for-editor@2017.3.0.rb
@@ -1,0 +1,14 @@
+cask 'unity-ios-support-for-editor@2017.3.0' do
+  version '2017.3.0f3,a9f86dcd79df'
+  sha256 'd50d6c96b40660cd1539f8ca10204e6c399358baa20643058d2ad8571a17543a'
+
+  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
+  name 'Unity iOS Build Support'
+  homepage 'https://unity3d.com/unity/'
+
+  depends_on cask: 'unity'
+
+  pkg "UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
+
+  uninstall pkgutil: 'com.unity3d.iOSSupport'
+end

--- a/Casks/unity-linux-support-for-editor@2017.3.0.rb
+++ b/Casks/unity-linux-support-for-editor@2017.3.0.rb
@@ -1,0 +1,14 @@
+cask 'unity-linux-support-for-editor@2017.3.0' do
+  version '2017.3.0f3,a9f86dcd79df'
+  sha256 '2bd298a2f5ab966ba7df702c9f173fda2fe762afd3ddb451ce8c077f28cab19a'
+
+  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
+  name 'Unity Linux Build Support'
+  homepage 'https://unity3d.com/unity/'
+
+  depends_on cask: 'unity'
+
+  pkg "UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
+
+  uninstall pkgutil: 'com.unity3d.LinuxStandaloneSupport'
+end

--- a/Casks/unity-linux-support-for-editor@2017.3.0.rb
+++ b/Casks/unity-linux-support-for-editor@2017.3.0.rb
@@ -6,7 +6,7 @@ cask 'unity-linux-support-for-editor@2017.3.0' do
   name 'Unity Linux Build Support'
   homepage 'https://unity3d.com/unity/'
 
-  depends_on cask: 'unity'
+  depends_on cask: 'unity@2017.3.0'
 
   pkg "UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
 

--- a/Casks/unity-standard-assets@2017.3.0.rb
+++ b/Casks/unity-standard-assets@2017.3.0.rb
@@ -1,0 +1,13 @@
+cask 'unity-standard-assets@2017.3.0' do
+  version '2017.3.0f3,a9f86dcd79df'
+  sha256 '91a177a0d42871856bf39152c345375cf7dfbfb1d77c06b05b0ce2c764730b5d'
+
+  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacStandardAssetsInstaller/StandardAssets-#{version.before_comma}.pkg"
+  name 'Unity Standard Assets'
+  homepage 'https://unity3d.com/unity'
+
+  pkg "StandardAssets-#{version.before_comma}.pkg"
+
+  uninstall quit:    'com.unity3d.UnityEditor5.x',
+            pkgutil: 'com.unity3d.StandardAssets'
+end

--- a/Casks/unity-windows-support-for-editor@2017.3.0.rb
+++ b/Casks/unity-windows-support-for-editor@2017.3.0.rb
@@ -1,0 +1,14 @@
+cask 'unity-windows-support-for-editor@2017.3.0' do
+  version '2017.3.0f3,a9f86dcd79df'
+  sha256 'b4b6c254f3bcb1c5f62dac44c187e6e4615c3758a2bd570727598e460d325c98'
+
+  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Support-for-Editor-#{version.before_comma}.pkg"
+  name 'Unity Windows Build Support'
+  homepage 'https://unity3d.com/unity/'
+
+  depends_on cask: 'unity'
+
+  pkg "UnitySetup-Windows-Support-for-Editor-#{version.before_comma}.pkg"
+
+  uninstall pkgutil: 'com.unity3d.WindowsStandaloneSupport'
+end

--- a/Casks/unity-windows-support-for-editor@2017.3.0.rb
+++ b/Casks/unity-windows-support-for-editor@2017.3.0.rb
@@ -6,7 +6,7 @@ cask 'unity-windows-support-for-editor@2017.3.0' do
   name 'Unity Windows Build Support'
   homepage 'https://unity3d.com/unity/'
 
-  depends_on cask: 'unity'
+  depends_on cask: 'unity@2017.3.0'
 
   pkg "UnitySetup-Windows-Support-for-Editor-#{version.before_comma}.pkg"
 

--- a/Casks/unity@2017.3.0.rb
+++ b/Casks/unity@2017.3.0.rb
@@ -1,0 +1,13 @@
+cask 'unity@2017.3.0' do
+  version '2017.3.0f3,a9f86dcd79df'
+  sha256 '65c4a2865d4e2d01cd08358dcca1a95537a882a17288deeb4439558ddb126c77'
+
+  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity.pkg"
+  name 'Unity Editor'
+  homepage 'https://unity3d.com/unity/'
+
+  pkg 'Unity.pkg'
+
+  uninstall quit:    'com.unity3d.UnityEditor5.x',
+            pkgutil: 'com.unity3d.UnityEditor5.x'
+end


### PR DESCRIPTION
Adds the following casks, which are currently [listed in the docs](https://docs.improbable.io/reference/12.1/shared/get-started/setup/mac) and should already exits:

brew cask install unity@2017.3.0
brew cask install unity-ios-support-for-editor@2017.3.0
brew cask install unity-linux-support-for-editor@2017.3.0
brew cask install unity-standard-assets@2017.3.0
brew cask install unity-windows-support-for-editor@2017.3.0