### PR TITLE
updating readme and removing deprecated license attribute

### DIFF
--- a/Casks/mono-mdk@4.4.2.rb
+++ b/Casks/mono-mdk@4.4.2.rb
@@ -5,7 +5,6 @@ cask 'mono-mdk@4.4.2' do
   url "https://download.mono-project.com/archive/#{version.sub(%r{\.[^.]*$}, '')}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   name 'Mono'
   homepage 'http://mono-project.com/'
-  license :oss
 
   conflicts_with cask: 'mono-mdk'
 

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ spatial, has.
 
 [How to contribute](./CONTRIBUTING.md)
 
-You can test casks locally before pushing to this repo by running: `brew install <path/to/cask.rb>`.
+You can test casks locally before pushing to this repo by running: `brew cask install <path/to/cask.rb>`.


### PR DESCRIPTION
successful run:
```
jessica-mbp:homebrew-spatialos jessica$ brew cask reinstall Casks/mono-mdk\@4.4.2.rb 
==> Satisfying dependencies
==> Downloading https://download.mono-project.com/archive/4.4.2/macos-10-universal/MonoFramework-MDK-4.4.2.11.macos10.xamarin.universal.pkg
Already downloaded: /Users/jessica/Library/Caches/Homebrew/Cask/mono-mdk@4.4.2--4.4.2.11.pkg
==> No checksum defined for Cask mono-mdk@4.4.2, skipping verification
==> Uninstalling Cask mono-mdk@4.4.2
==> Running uninstall process for mono-mdk@4.4.2; your password may be necessary
==> Uninstalling packages:
com.xamarin.mono-MDK.pkg
==> Purging files for version 4.4.2.11 of Cask mono-mdk@4.4.2
==> Installing Cask mono-mdk@4.4.2
==> Running installer for mono-mdk@4.4.2; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are ignored.
==> installer: Package name is Mono Framework
==> installer: Installing at base path /
==> installer: The install was successful.
🍺  mono-mdk@4.4.2 was successfully installed!
```